### PR TITLE
Add json output format

### DIFF
--- a/bin/metadata-json-deps
+++ b/bin/metadata-json-deps
@@ -16,4 +16,4 @@ OptionParser.new do |opts|
   end
 end.parse!(into: options)
 
-exit(MetadataJsonDeps.run(ARGV, options.fetch(:verbose, false), format: options[:format] || :text))
+exit(MetadataJsonDeps.run(ARGV, options))

--- a/bin/metadata-json-deps
+++ b/bin/metadata-json-deps
@@ -6,6 +6,14 @@ require 'metadata_json_deps'
 options = {}
 OptionParser.new do |opts|
   opts.on("-v", "--[no-]verbose", "Run verbosely")
+  opts.on("-f", "--format FORMAT", "Output format: text (default) or json") do |f|
+    options[:format] = case f.downcase
+    when "text" then :text
+    when "json" then :json
+    else
+      raise OptionParser::InvalidArgument, f
+    end
+  end
 end.parse!(into: options)
 
-exit(MetadataJsonDeps.run(ARGV, options[:verbose]))
+exit(MetadataJsonDeps.run(ARGV, options.fetch(:verbose, false), format: options[:format] || :text))

--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'puppet_forge'
 require 'puppet_metadata'
 
@@ -82,22 +83,34 @@ module MetadataJsonDeps
   #   The filenames to run on
   # @param [Boolean] verbose
   #   Whether or not to run in verbose mode
+  # @param [Symbol] format
+  #   :text or :json
   # @return [Integer] the exit code
-  def self.run(filenames, verbose = false)
+  def self.run(filenames, verbose = false, format: :text)
     forge = ForgeVersions.new
 
     exit_code = 0
+    json = format.to_sym == :json
+    doc = {'files' => []} if json
 
     filenames.each do |filename|
-      puts "Checking #{filename}"
+      unless json
+        puts "Checking #{filename}"
+      end
       metadata = PuppetMetadata.read(filename)
+      file_entry = json ? {'path' => filename, 'dependencies' => []} : nil
 
-      metadata.dependencies.map do |dependency, constraint|
+      metadata.dependencies.each do |dependency, constraint|
         mod = forge.get_module(dependency)
 
         if mod.deprecated_at
           exit_code |= 2
-          if mod.superseded_by
+          if json
+            dep = {'name' => dependency, 'version_requirement' => constraint.to_s, 'status' => 'deprecated'}
+            dep['superseded_by'] = mod.superseded_by[:slug] if mod.superseded_by
+            dep['deprecated_for'] = mod.deprecated_for if mod.deprecated_for
+            file_entry['dependencies'] << dep
+          elsif mod.superseded_by
             puts "  #{dependency} was superseded by #{mod.superseded_by[:slug]}"
           elsif mod.deprecated_for
             puts "  #{dependency} was deprecated: #{mod.deprecated_for}"
@@ -108,16 +121,36 @@ module MetadataJsonDeps
           current = mod.current_release.version
 
           if metadata.satisfies_dependency?(dependency, current)
-            if verbose
+            if json
+              file_entry['dependencies'] << {
+                'name' => dependency,
+                'version_requirement' => constraint.to_s,
+                'status' => 'satisfies',
+                'current_release' => current,
+              }
+            elsif verbose
               puts "  #{dependency} (#{constraint}) matches #{current}"
             end
           else
             exit_code |= 1
-            puts "  #{dependency} (#{constraint}) doesn't match #{current}"
+            if json
+              file_entry['dependencies'] << {
+                'name' => dependency,
+                'version_requirement' => constraint.to_s,
+                'status' => 'unsatisfied',
+                'current_release' => current,
+              }
+            else
+              puts "  #{dependency} (#{constraint}) doesn't match #{current}"
+            end
           end
         end
       end
+
+      doc['files'] << file_entry if json
     end
+
+    puts JSON.pretty_generate(doc) if json
 
     exit_code
   rescue Interrupt

--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -81,16 +81,14 @@ module MetadataJsonDeps
   # @summary Run the application
   # @param [Array[String]] filenames
   #   The filenames to run on
-  # @param [Boolean] verbose
-  #   Whether or not to run in verbose mode
-  # @param [Symbol] format
-  #   :text or :json
+  # @param [Hash] options
+  #   The command line options
   # @return [Integer] the exit code
-  def self.run(filenames, verbose = false, format: :text)
+  def self.run(filenames, options = {})
     forge = ForgeVersions.new
 
     exit_code = 0
-    json = format.to_sym == :json
+    json = options[:format] == :json
     doc = {'files' => []} if json
 
     filenames.each do |filename|
@@ -128,7 +126,7 @@ module MetadataJsonDeps
                 'status' => 'satisfies',
                 'current_release' => current,
               }
-            elsif verbose
+            elsif options[:verbose]
               puts "  #{dependency} (#{constraint}) matches #{current}"
             end
           else

--- a/spec/metadata_json_deps_spec.rb
+++ b/spec/metadata_json_deps_spec.rb
@@ -1,13 +1,31 @@
 require 'spec_helper'
 require 'json'
+require 'stringio'
 require 'tempfile'
 
 describe MetadataJsonDeps do
+  def capture_stdout
+    io = StringIO.new
+    prior = $stdout
+    $stdout = io
+    yield
+    io.string
+  ensure
+    $stdout = prior
+  end
+
   context 'no filenames' do
     subject { described_class.run([]) }
 
     it { expect { subject }.to_not output.to_stdout }
     it { expect { subject }.to_not output.to_stderr }
+
+    context 'with json format' do
+      it 'prints an empty document' do
+        out = capture_stdout { described_class.run([], format: :json) }
+        expect(JSON.parse(out)).to eq('files' => [])
+      end
+    end
   end
 
   context 'with a module' do
@@ -71,6 +89,38 @@ describe MetadataJsonDeps do
 
       it { expect { subject }.to output(%r{\AChecking .+puppet-module.+json\n  theforeman/motd \(< 0\.1\.0\) doesn't match \d+\.\d+\.\d+\Z}).to_stdout }
       it { expect { subject }.to_not output.to_stderr }
+
+      context 'with json format' do
+        it 'reports unsatisfied dependency in json' do
+          json_out = Tempfile.create(['puppet-module', '.json']) do |f|
+            mod = {
+              "name": "puppet-dummy",
+              "author": "Nobody",
+              "license": "none",
+              "source": "/dev/null",
+              "summary": "Dummy",
+              "version": "0.0.1",
+              "dependencies": [
+                {
+                  "name": module_name,
+                  "version_requirement": module_version,
+                },
+              ],
+            }
+            f.write(mod.to_json)
+            f.flush
+
+            capture_stdout { described_class.run([f.path], format: :json) }
+          end
+
+          data = JSON.parse(json_out)
+          dep = data.fetch('files').first.fetch('dependencies').first
+          expect(dep['name']).to eq('theforeman/motd')
+          expect(dep['version_requirement']).to eq('< 0.1.0')
+          expect(dep['status']).to eq('unsatisfied')
+          expect(dep['current_release']).to match(/\A\d+\.\d+\.\d+\z/)
+        end
+      end
     end
   end
 

--- a/spec/metadata_json_deps_spec.rb
+++ b/spec/metadata_json_deps_spec.rb
@@ -4,28 +4,20 @@ require 'stringio'
 require 'tempfile'
 
 describe MetadataJsonDeps do
-  def capture_stdout
-    io = StringIO.new
-    prior = $stdout
-    $stdout = io
-    yield
-    io.string
-  ensure
-    $stdout = prior
-  end
-
   context 'no filenames' do
     subject { described_class.run([]) }
 
     it { expect { subject }.to_not output.to_stdout }
     it { expect { subject }.to_not output.to_stderr }
+  end
 
-    context 'with json format' do
-      it 'prints an empty document' do
-        out = capture_stdout { described_class.run([], format: :json) }
-        expect(JSON.parse(out)).to eq('files' => [])
-      end
-    end
+  context 'with json format' do
+    subject { described_class.run([], {format: :json}) }
+
+    let(:expected_output) { {'files' => []} }
+
+    it { expect { subject }.to output(include(JSON.pretty_generate(expected_output))).to_stdout }
+    it { expect { subject }.to_not output.to_stderr }
   end
 
   context 'with a module' do
@@ -48,11 +40,12 @@ describe MetadataJsonDeps do
         f.write(mod.to_json)
         f.flush
 
-        described_class.run([f.path])
+        described_class.run([f.path], options)
       end
     end
 
     let(:module_version) { '>= 0' }
+    let(:options) { {} }
 
     context 'that depends on a deprecated module' do
       context 'with replacement' do
@@ -60,6 +53,17 @@ describe MetadataJsonDeps do
 
         it { expect { subject }.to output(%r{\AChecking .+puppet-module.+\.json\n  puppetlabs/mssql was superseded by puppetlabs-sqlserver\Z}).to_stdout }
         it { expect { subject }.to_not output.to_stderr }
+
+        context 'with json format' do
+          let(:options) { {format: :json} }
+
+          it { expect { subject }.to output(
+            match(/"name": "puppetlabs\/mssql"/)
+            .and(match(/"status": "deprecated"/))
+            .and(match(/"superseded_by": "puppetlabs-sqlserver"/))
+          ).to_stdout }
+          it { expect { subject }.to_not output.to_stderr }
+        end
       end
 
       context 'without replacement' do
@@ -68,6 +72,16 @@ describe MetadataJsonDeps do
 
           it { expect { subject }.to output(%r{\AChecking .+puppet-module.+\.json\n  puppetlabs/dsc was deprecated: Migrate to https://forge\.puppet\.com/dsc modules\Z}).to_stdout }
           it { expect { subject }.to_not output.to_stderr }
+
+          context 'with json format' do
+            let(:options) { {format: :json} }
+
+            it { expect { subject }.to output(
+              match(/"name": "puppetlabs\/dsc"/)
+              .and(match(/"status": "deprecated"/))
+              .and(match(/"deprecated_for": "Migrate to https:\/\/forge\.puppet\.com\/dsc modules"/))
+            ).to_stdout }
+          end
         end
 
         # TODO find a module without a reason
@@ -81,6 +95,16 @@ describe MetadataJsonDeps do
 
       it { expect { subject }.to output(%r{\AChecking .+puppet-module.+json\Z}).to_stdout }
       it { expect { subject }.to_not output.to_stderr }
+
+      context 'with json format' do
+        let(:options) { {format: :json} }
+
+        it { expect { subject }.to output(
+          match(/"name": "puppetlabs\/stdlib"/)
+          .and(match(/"status": "satisfies"/))
+          .and(match(/"current_release": "\d+\.\d+\.\d+"/))
+        ).to_stdout }
+      end
     end
 
     context 'with an outdated dependency' do
@@ -91,35 +115,13 @@ describe MetadataJsonDeps do
       it { expect { subject }.to_not output.to_stderr }
 
       context 'with json format' do
-        it 'reports unsatisfied dependency in json' do
-          json_out = Tempfile.create(['puppet-module', '.json']) do |f|
-            mod = {
-              "name": "puppet-dummy",
-              "author": "Nobody",
-              "license": "none",
-              "source": "/dev/null",
-              "summary": "Dummy",
-              "version": "0.0.1",
-              "dependencies": [
-                {
-                  "name": module_name,
-                  "version_requirement": module_version,
-                },
-              ],
-            }
-            f.write(mod.to_json)
-            f.flush
+        let(:options) { {format: :json} }
 
-            capture_stdout { described_class.run([f.path], format: :json) }
-          end
-
-          data = JSON.parse(json_out)
-          dep = data.fetch('files').first.fetch('dependencies').first
-          expect(dep['name']).to eq('theforeman/motd')
-          expect(dep['version_requirement']).to eq('< 0.1.0')
-          expect(dep['status']).to eq('unsatisfied')
-          expect(dep['current_release']).to match(/\A\d+\.\d+\.\d+\z/)
-        end
+        it { expect { subject }.to output(
+          match(/"name": "theforeman\/motd"/)
+          .and(match(/"status": "unsatisfied"/))
+          .and(match(/"current_release": "\d+\.\d+\.\d+"/))
+        ).to_stdout }
       end
     end
   end


### PR DESCRIPTION
This PR adds an output option as json format.

```
{
  "files": [
    {
      "path": "../vv-server-puppet/modules/nexus/metadata.json",
      "dependencies": [
        {
          "name": "puppetlabs/device_manager",
          "version_requirement": ">=3.0.0 < 5.0.0",
          "status": "deprecated"
        },
        {
          "name": "puppetlabs/stdlib",
          "version_requirement": ">=4.0.0 < 10.0.0",
          "status": "satisfies",
          "current_release": "9.7.0"
        },
        {
          "name": "puppet/archive",
          "version_requirement": ">=3.2.1 < 8.0.0",
          "status": "unsatisfied",
          "current_release": "8.1.0"
        },
        {
          "name": "puppet/extlib",
          "version_requirement": ">=2.1.0 < 8.0.0",
          "status": "satisfies",
          "current_release": "7.5.1"
        }
      ]
    }
  ]
}
```

The code was mainly written by Cursor with 'composer-2-fast' model.