### PR TITLE
Rework internal to support multiple output formats

### DIFF
--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -77,6 +77,77 @@ module MetadataJsonDeps
     [requirement.to_s, new]
   end
 
+  # Build dependency check results for one metadata file (for pluggable formatters).
+  #
+  # @param [String] filename path to a metadata.json file
+  # @param [ForgeVersions] forge forge client (for tests or shared cache)
+  # @return [Hash] { filename: String, checks: Array<Hash> }. Each check is one of:
+  #   - { type: :deprecated, name:, superseded_by:, deprecated_for: }
+  #   - { type: :satisfies, name:, constraint:, current: }
+  #   - { type: :unsatisfied, name:, constraint:, current: }
+  def self.dependency_check_results(filename, forge)
+    metadata = PuppetMetadata.read(filename)
+
+    checks = metadata.dependencies.map do |dependency, constraint|
+      mod = forge.get_module(dependency)
+
+      if mod.deprecated_at
+        {
+          type: :deprecated,
+          name: dependency,
+          superseded_by: mod.superseded_by&.fetch(:slug, nil),
+          deprecated_for: mod.deprecated_for,
+        }
+      else
+        current = mod.current_release.version
+        type = metadata.satisfies_dependency?(dependency, current) ? :satisfies : :unsatisfied
+        {type: type, name: dependency, constraint: constraint.to_s, current: current}
+      end
+    end
+
+    {filename: filename, name: metadata.name, checks: checks}
+  end
+
+  # Format dependency check results as text
+  #
+  # @param [Array[String]] filenames
+  #   The filenames to run on
+  # @param [ForgeVersions] forge forge client (for tests or shared cache)
+  # @param [Boolean] verbose
+  #   Whether or not to run in verbose mode
+  # @return [Integer] the exit code  def self.format_text(filenames, forge, verbose)
+  def self.format_text(filenames, forge, verbose)
+    exit_code = 0
+
+    filenames.each do |filename|
+      puts "Checking #{filename}"
+      results = dependency_check_results(filename, forge)
+      results[:checks].each do | mod |
+        if mod[:type] == :deprecated
+          exit_code |= 2
+          if mod[:superseded_by]
+            puts "  #{mod[:name]} was superseded by #{mod[:superseded_by]}"
+          elsif mod[:deprecated_for]
+            puts "  #{mod[:name]} was deprecated: #{mod[:deprecated_for]}"
+          else
+            puts "  #{mod[:name]} was deprecated"
+          end
+        else
+          if mod[:type] == :satisfies
+            if verbose
+              puts "  #{mod[:name]} (#{mod[:constraint]}) matches #{mod[:current]}"
+            end
+          else
+            exit_code |= 1
+            puts "  #{mod[:name]} (#{mod[:constraint]}) doesn't match #{mod[:current]}"
+          end
+        end
+      end
+    end
+
+    exit_code
+  end
+
   # @summary Run the application
   # @param [Array[String]] filenames
   #   The filenames to run on
@@ -86,40 +157,7 @@ module MetadataJsonDeps
   def self.run(filenames, verbose = false)
     forge = ForgeVersions.new
 
-    exit_code = 0
-
-    filenames.each do |filename|
-      puts "Checking #{filename}"
-      metadata = PuppetMetadata.read(filename)
-
-      metadata.dependencies.map do |dependency, constraint|
-        mod = forge.get_module(dependency)
-
-        if mod.deprecated_at
-          exit_code |= 2
-          if mod.superseded_by
-            puts "  #{dependency} was superseded by #{mod.superseded_by[:slug]}"
-          elsif mod.deprecated_for
-            puts "  #{dependency} was deprecated: #{mod.deprecated_for}"
-          else
-            puts "  #{dependency} was deprecated"
-          end
-        else
-          current = mod.current_release.version
-
-          if metadata.satisfies_dependency?(dependency, current)
-            if verbose
-              puts "  #{dependency} (#{constraint}) matches #{current}"
-            end
-          else
-            exit_code |= 1
-            puts "  #{dependency} (#{constraint}) doesn't match #{current}"
-          end
-        end
-      end
-    end
-
-    exit_code
+    format_text(filenames, forge, verbose)
   rescue Interrupt
     0
   end

--- a/spec/metadata_json_deps_spec.rb
+++ b/spec/metadata_json_deps_spec.rb
@@ -11,28 +11,30 @@ describe MetadataJsonDeps do
   end
 
   context 'with a module' do
-    subject do
-      Tempfile.create(['puppet-module', '.json']) do |f|
-        mod = {
-          "name": "puppet-dummy",
-          "author": "Nobody",
-          "license": "none",
-          "source": "/dev/null",
-          "summary": "Dummy",
-          "version": "0.0.1",
-          "dependencies": [
-            {
-              "name": module_name,
-              "version_requirement": module_version,
-            },
-          ],
-        }
-        f.write(mod.to_json)
-        f.flush
-
-        described_class.run([f.path])
-      end
+    let(:metadata_file) do
+      f = Tempfile.new(['puppet-module', '.json'])
+      f.write({
+        name: "puppet-dummy",
+        author: "Nobody",
+        license: "none",
+        source: "/dev/null",
+        summary: "Dummy",
+        version: "0.0.1",
+        dependencies: [
+          {
+            name: module_name,
+            version_requirement: module_version
+          },
+        ],
+      }.to_json)
+      f.flush
+      f
     end
+    after { metadata_file.close! }
+    subject { described_class.run([metadata_file.path]) }
+
+    let(:forge) { MetadataJsonDeps::ForgeVersions.new }
+    let(:check_results) { described_class.dependency_check_results(metadata_file.path, forge) }
 
     let(:module_version) { '>= 0' }
 
@@ -42,6 +44,7 @@ describe MetadataJsonDeps do
 
         it { expect { subject }.to output(%r{\AChecking .+puppet-module.+\.json\n  puppetlabs/mssql was superseded by puppetlabs-sqlserver\Z}).to_stdout }
         it { expect { subject }.to_not output.to_stderr }
+        it { expect(check_results[:checks]).to include(a_hash_including(type: :deprecated, name: 'puppetlabs/mssql', superseded_by: 'puppetlabs-sqlserver')) }
       end
 
       context 'without replacement' do
@@ -50,6 +53,7 @@ describe MetadataJsonDeps do
 
           it { expect { subject }.to output(%r{\AChecking .+puppet-module.+\.json\n  puppetlabs/dsc was deprecated: Migrate to https://forge\.puppet\.com/dsc modules\Z}).to_stdout }
           it { expect { subject }.to_not output.to_stderr }
+          it { expect(check_results[:checks]).to include(a_hash_including(type: :deprecated, name: 'puppetlabs/dsc')) }
         end
 
         # TODO find a module without a reason
@@ -63,6 +67,7 @@ describe MetadataJsonDeps do
 
       it { expect { subject }.to output(%r{\AChecking .+puppet-module.+json\Z}).to_stdout }
       it { expect { subject }.to_not output.to_stderr }
+      it { expect(check_results[:checks]).to include(a_hash_including(type: :satisfies, name: 'puppetlabs/stdlib')) }
     end
 
     context 'with an outdated dependency' do
@@ -71,6 +76,7 @@ describe MetadataJsonDeps do
 
       it { expect { subject }.to output(%r{\AChecking .+puppet-module.+json\n  theforeman/motd \(< 0\.1\.0\) doesn't match \d+\.\d+\.\d+\Z}).to_stdout }
       it { expect { subject }.to_not output.to_stderr }
+      it { expect(check_results[:checks]).to include(a_hash_including(type: :unsatisfied, name: 'theforeman/motd', constraint: '< 0.1.0')) }
     end
   end
 


### PR DESCRIPTION
This PR reworks some internals to be able to easily support multiple output formats like json.

It is the basement for another PR and was created to have a more easily reviewable PR.